### PR TITLE
fix: css toggler button for responsive layouts

### DIFF
--- a/resources/_gen/assets/css/css/tailwind.css_990e76d48acec528466601e88ce83c6e.content
+++ b/resources/_gen/assets/css/css/tailwind.css_990e76d48acec528466601e88ce83c6e.content
@@ -868,6 +868,9 @@ video {
   margin-left: auto;
   margin-right: auto;
 }
+.-mt-2 {
+  margin-top: -0.5rem;
+}
 .mb-5 {
   margin-bottom: 1.25rem;
 }
@@ -882,6 +885,9 @@ video {
 }
 .grid {
   display: grid;
+}
+.hidden {
+  display: none;
 }
 .h-20 {
   height: 5rem;
@@ -946,6 +952,10 @@ video {
 .stroke-2 {
   stroke-width: 2;
 }
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
 .py-10 {
   padding-top: 2.5rem;
   padding-bottom: 2.5rem;
@@ -1001,7 +1011,16 @@ nav a.active {
 }
 /* Content overrides */
 #content {
+  padding-left: 1rem;
+  padding-right: 1rem;
   line-height: 1.5;
+}
+@media (min-width: 1024px) {
+
+  #content {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
 }
 #content a {
   font-weight: 700;
@@ -1325,12 +1344,20 @@ nav a.active {
   width: 1.5rem;
 }
 .title-large {
+  text-wrap: balance;
+  text-align: left;
   font-size: 2.25rem;
   line-height: 2.5rem;
   font-weight: 700;
   line-height: 1.375;
   --tw-text-opacity: 1;
   color: rgb(17 24 39 / var(--tw-text-opacity));
+}
+@media (min-width: 1024px) {
+
+  .title-large {
+    text-align: justify;
+  }
 }
 :is(:where(.dark) .title-large) {
   --tw-text-opacity: 1;
@@ -1372,4 +1399,25 @@ nav a.active {
   .sm\:gap-10 {
     gap: 2.5rem;
   }
+}
+@media (min-width: 1024px) {
+
+  .lg\:inline-block {
+    display: inline-block;
+  }
+
+  .lg\:hidden {
+    display: none;
+  }
+
+  .lg\:px-0 {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
+}
+:is(:where(.dark) .dark\:block) {
+  display: block;
+}
+:is(:where(.dark) .dark\:hidden) {
+  display: none;
 }

--- a/themes/lowkey/assets/css/tailwind.css
+++ b/themes/lowkey/assets/css/tailwind.css
@@ -234,7 +234,7 @@
   
   /* Content overrides */
   #content {
-    @apply leading-normal;
+    @apply leading-normal px-4 lg:px-0;
   }
 
   #content a {
@@ -363,7 +363,7 @@
   }
 
   .title-large {
-    @apply text-4xl leading-snug font-bold text-gray-900 dark:text-gray-300;
+    @apply text-4xl leading-snug font-bold text-gray-900 dark:text-gray-300 text-balance text-left lg:text-justify;
   }
 
   .title-small {

--- a/themes/lowkey/layouts/_default/baseof.html
+++ b/themes/lowkey/layouts/_default/baseof.html
@@ -7,7 +7,9 @@
   <body class="max-w-screen-md mx-auto">
     <div class="header">
       {{ partial "header/index" . }}
-      {{ partial "header/theme-button" . }}
+      <div class="lg:inline-block hidden">
+        {{ partial "header/theme-button" . }}
+      </div>
     </div>
   
     <main id="content">

--- a/themes/lowkey/layouts/partials/header/nav.html
+++ b/themes/lowkey/layouts/partials/header/nav.html
@@ -1,5 +1,5 @@
 <nav>
-  <ul>
+  <ul class="px-4 lg:px-0">
     {{ $currentPage := . }} 
     {{ range site.Menus.main }} 
     {{- $menu_item_url := (cond (strings.HasSuffix .URL "/") .URL (printf "%s/" .URL) ) | absLangURL }} 
@@ -10,5 +10,8 @@
       </a>
     </li>
     {{ end }}
+    <li class="-mt-2 block lg:hidden">
+      {{ partial "header/theme-button" . }}
+    </li>
   </ul>
 </nav>

--- a/themes/lowkey/layouts/partials/header/theme-button.html
+++ b/themes/lowkey/layouts/partials/header/theme-button.html
@@ -1,6 +1,6 @@
 <button class="toggle-theme" aria-label="Toggle Theme" title="Toggle Theme" onclick="toggleTheme()">
-  <span class="theme-icon light"> {{ partial "utils/icon" "sun" }} </span>
-  <span class="theme-icon dark"> {{ partial "utils/icon" "moon" }} </span>
+  <span class="theme-icon light hidden dark:block"> {{ partial "utils/icon" "sun" }} </span>
+  <span class="theme-icon dark block dark:hidden"> {{ partial "utils/icon" "moon" }} </span>
 </button>
 
 <script>


### PR DESCRIPTION
# Descrição

Como dito no twitter e na issue https://github.com/eminetto/eltonminetto.net/issues/5, segue a correção.

Também fiz uma pequena correção no ícone de light/dark mode para mobile.

# Screenshots

<img width="359" alt="image" src="https://github.com/eminetto/eltonminetto.net/assets/22946697/3ff6701f-1e15-471e-a94d-98be3fa741a4">

<img width="1384" alt="image" src="https://github.com/eminetto/eltonminetto.net/assets/22946697/f380d5b2-60b4-4a50-a4f5-1759282dae88">

