### PR TITLE
feat: add script for google analytics

### DIFF
--- a/themes/lowkey/layouts/partials/head/meta.html
+++ b/themes/lowkey/layouts/partials/head/meta.html
@@ -1,8 +1,26 @@
-<meta charset="UTF-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta charset="UTF-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }}{{ end }}</title>
-<meta name="description" content="{{ if .IsPage }}{{ or .Params.description .Summary }}{{ else if .IsHome }}{{ .Site.Params.description }}{{ else if .IsNode }}{{ or .Params.description .Summary }}{{ end }}">
-<link rel="canonical" href="{{ .Permalink }}">
+<meta
+  name="description"
+  content="{{ if .IsPage }}{{ or .Params.description .Summary }}{{ else if .IsHome }}{{ .Site.Params.description }}{{ else if .IsNode }}{{ or .Params.description .Summary }}{{ end }}"
+/>
+<link rel="canonical" href="{{ .Permalink }}" />
 <link rel="robots" href="/robots.txt" />
 
+<!-- Google Analytics -->
+<script
+  defer
+  src="https://www.googletagmanager.com/gtag/js?id={{ .Site.GoogleAnalytics }}"
+></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+  gtag('js', new Date());
+
+  gtag('config', '{{ .Site.GoogleAnalytics }}');
+</script>
+<!-- End Google Analytics -->


### PR DESCRIPTION
Migrei meu blog do Jekyll para o Hugo, e gostei bastante do tema que você utilizou, resolvi usar também, mas achei alguns problemas, um deles é que o google analytics não funciona, adicionamos no `hugo.toml` o  `googleAnalytics`, porém não era adicionado nenhum script no `head`. 

Fiz a correção e criei um [pr](https://github.com/nixentric/Lowkey-Hugo-Theme/pull/29) para o Lowkey, já foi feito o merge, porém acredito que o seu tema possa estar com esse mesmo problema, por isso resolvi fazer esse pr.