### PR TITLE
feat: remove analytics partial

### DIFF
--- a/themes/lowkey/layouts/partials/footer/analytics.html
+++ b/themes/lowkey/layouts/partials/footer/analytics.html
@@ -1,9 +1,0 @@
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-B6W400SFM4"></script>
-<script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
-    gtag('js', new Date());
-
-    gtag('config', 'G-B6W400SFM4');
-</script>

--- a/themes/lowkey/layouts/partials/footer/index.html
+++ b/themes/lowkey/layouts/partials/footer/index.html
@@ -2,4 +2,3 @@
     {{ partial "footer/copyright" . }}
     {{ partial "footer/social" . }}
 </footer>
-{{ partial "footer/analytics" . }}


### PR DESCRIPTION
This pull request mainly focuses on the removal of Google Analytics from the website. The Google tag script, which was previously included in the footer, has been removed. This has also led to the removal of the analytics partial from the main footer file.

Here are the key changes:

Removal of Google Analytics:

* [`themes/lowkey/layouts/partials/footer/analytics.html`](diffhunk://#diff-b10959fa4c417bf5e96487379c89b16832f9546958b136de3d9f17244ebaf16dL1-L9): The Google tag script, which was used for Google Analytics, has been removed entirely from this file.
* [`themes/lowkey/layouts/partials/footer/index.html`](diffhunk://#diff-f14fcb97b2fc8618525d87f73391fcdb3dc64df35804c5d5a3c84174da042c70L5): The reference to the analytics partial has been removed from the main footer file.